### PR TITLE
Fix error importing InteractiveGenerator

### DIFF
--- a/easy_markers/src/easy_markers/interactive.py
+++ b/easy_markers/src/easy_markers/interactive.py
@@ -3,6 +3,7 @@ import roslib; roslib.load_manifest('easy_markers')
 from easy_markers.generator import MarkerGenerator
 from interactive_markers.interactive_marker_server import *
 from interactive_markers.menu_handler import *
+from visualization_msgs.msg import InteractiveMarkerControl
 
 TYPEDATA = {
     'rotate_x': [1,1,0,0, InteractiveMarkerControl.ROTATE_AXIS],


### PR DESCRIPTION
`interactive_marker_server` used to do an `import *` from `visualization_msgs.msg` but doesn't anymore, and doesn't explicitly import `InteractiveMarkerControl`.

```
>>> from easy_markers.interactive import InteractiveGenerator
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lazewatd/Dropbox/dev/tfp_ws/src/wu_ros_tools/easy_markers/src/easy_markers/interactive.py", line 9, in <module>
    'rotate_x': [1,1,0,0, InteractiveMarkerControl.ROTATE_AXIS],
NameError: name 'InteractiveMarkerControl' is not defined
```
